### PR TITLE
update to Comonicon 0.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5'
+          - '1'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Comonicon.toml
+++ b/Comonicon.toml
@@ -4,3 +4,9 @@ name = "searchable"
 completion = true
 quiet = false
 optimize = 2
+
+[sysimg]
+path="deps"
+incremental=true
+filter_stdlibs=false
+cpu_target="native"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ unpaper_jll = "d52248c9-e08a-51c2-9066-05d0bf3e6245"
 [compat]
 Aqua = "0.5"
 CSV = "0.8"
-Comonicon = "0.10"
+Comonicon = "0.11"
 Poppler_jll = "0.87"
 ProgressMeter = "1.5"
 Scratch = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ Poppler_jll = "0.87"
 ProgressMeter = "1.5"
 Scratch = "1"
 Tesseract_jll = "4.1.1"
-julia = "1.5"
+julia = "1.6"
 unpaper_jll = "6.1.0"
 
 [extras]


### PR DESCRIPTION
Not sure if you want to use a system image or even just build an app for this, I find this package itself is quite slow to start (costs over 1s on my machine), after you enable system image build it only costs 200ms. I enabled it in this PR.

There will be some instability for version 0.11 since it's a brand new rewrite, 0.11 is also a little bit slower since we support parsing more syntax in the terminal.